### PR TITLE
Optimize Processor by adding support for JSON Arrays

### DIFF
--- a/nifi-bigquery-nar/pom.xml
+++ b/nifi-bigquery-nar/pom.xml
@@ -23,7 +23,7 @@
     </parent>
 
     <artifactId>nifi-bigquery-nar</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1</version>
     <packaging>nar</packaging>
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-bigquery-processors</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1</version>
         </dependency>
     </dependencies>
 

--- a/nifi-bigquery-processors/src/test/java/org/apache/nifi/processors/bigquery/PutBigqueryTest.java
+++ b/nifi-bigquery-processors/src/test/java/org/apache/nifi/processors/bigquery/PutBigqueryTest.java
@@ -75,6 +75,47 @@ public class PutBigqueryTest {
 
 
     }
+    
+    @Test
+    public void shouldSuccessfulWhenDataArrayAreWriteCorrectly() {
+        
+        // Inject a mock BigQuery to insert data
+        final BigQuery mockBigQuery = Mockito.mock(BigQuery.class);
+        
+        
+        //mock row of data to insert
+        Map<String, Integer> row = new HashMap<>();
+        row.put("test_col", 2);
+        InsertAllRequest.RowToInsert rowToInsert = InsertAllRequest.RowToInsert.of(row);
+        //mock insert bigquery insert request
+        InsertAllRequest insertAllRequest = InsertAllRequest.of("test_dataset", "test_table", rowToInsert);
+        // mock success writing
+        InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+        when(insertAllResponse.hasErrors()).thenReturn(false);
+        when(mockBigQuery.insertAll(insertAllRequest)).thenReturn(insertAllResponse);
+        
+        putBigquery = new PutBigquery() {
+            @Override
+            protected BigQuery getBigQuery() {
+                return mockBigQuery;
+            }
+        };
+        
+        final TestRunner putRunner = TestRunners.newTestRunner(putBigquery);
+        
+        putRunner.setProperty(AbstractBigqueryProcessor.SERVICE_ACCOUNT_CREDENTIALS_JSON, "{}");
+        putRunner.setProperty(PutBigquery.TABLE, "test_table");
+        putRunner.setProperty(PutBigquery.DATASET, "test_dataset");
+        
+        String document = "[{\"test_col\": 2}]";
+        putRunner.enqueue(document.getBytes());
+        
+        putRunner.run(1,true,false);
+        
+        putRunner.assertAllFlowFilesTransferred(AbstractBigqueryProcessor.REL_SUCCESS, 1);
+        
+        
+    }
 
     @Test
     public void shouldFailWhenFlowFileIsNotAValidJson() {


### PR DESCRIPTION
At the moment this processor adds JSON documents to BigQuery tables, one document at a time.

However in cases where uses are streaming a JSON Array of JSON Objects, where each JSON Object represents a row in the BigQuery table, then it woud be advantages to allow this proccessor to take a JSONArray as input, insert the rows in one statement to BigQuery and output the flowfile.

Please accept this modification to the processor or let's discuss what you think is best.

Btw, great code.

Kind Regards,
Alysia